### PR TITLE
Generated scripted tests

### DIFF
--- a/src/sbt-test/scripted-sources-plugin/basic-plugin-project/example/project/plugins.sbt
+++ b/src/sbt-test/scripted-sources-plugin/basic-plugin-project/example/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("basic-plugin-project" % "basic-plugin-project" % pluginVersion)

--- a/src/sbt-test/scripted-sources-plugin/basic-plugin-project/src/sbt-test-base/project/plugins.sbt
+++ b/src/sbt-test/scripted-sources-plugin/basic-plugin-project/src/sbt-test-base/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin(
+  "basic-plugin-project" % "basic-plugin-project" % sys.props.getOrElse(
+    "plugin.version",
+    sys.error("'plugin.version' environment variable is not set")
+  )
+)

--- a/src/sbt-test/scripted-sources-plugin/basic-plugin-project/src/sbt-test/basic-plugin-project/basic-project/.sources
+++ b/src/sbt-test/scripted-sources-plugin/basic-plugin-project/src/sbt-test/basic-plugin-project/basic-project/.sources
@@ -1,1 +1,2 @@
+src/sbt-test-base
 example

--- a/src/sbt-test/scripted-sources-plugin/basic-plugin-project/test
+++ b/src/sbt-test/scripted-sources-plugin/basic-plugin-project/test
@@ -1,2 +1,8 @@
+$ absent target/generated-sbt-test
 > scripted
-# TODO create better tests to check if watch mode and source overriding from scripted tests works
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/project/plugins.sbt src/sbt-test-base/project/plugins.sbt
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/project/TestPlugins.sbt src/sbt-test/basic-plugin-project/basic-project/project/TestPlugins.sbt
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/TestBuild.sbt src/sbt-test/basic-plugin-project/basic-project/TestBuild.sbt
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/src/main/scala/example/Hello.scala example/src/main/scala/example/Hello.scala
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/index.html example/index.html
+$ must-mirror target/generated-sbt-test/basic-plugin-project/basic-project/style.css example/style.css

--- a/src/sbt-test/scripted-sources-plugin/basic-plugin-project/test
+++ b/src/sbt-test/scripted-sources-plugin/basic-plugin-project/test
@@ -1,13 +1,2 @@
-$ absent src/sbt-test/basic-plugin-project/basic-project/project/plugins.sbt
-$ absent src/sbt-test/basic-plugin-project/basic-project/src/main/scala/example/Hello.scala
-$ absent src/sbt-test/basic-plugin-project/basic-project/index.html
-$ absent src/sbt-test/basic-plugin-project/basic-project/style.css
-
--> scriptedSourcesCheck
 > scripted
-> scriptedSourcesCheck
-
-$ exists src/sbt-test/basic-plugin-project/basic-project/project/plugins.sbt
-$ exists src/sbt-test/basic-plugin-project/basic-project/src/main/scala/example/Hello.scala
-$ exists src/sbt-test/basic-plugin-project/basic-project/index.html
-$ exists src/sbt-test/basic-plugin-project/basic-project/style.css
+# TODO create better tests to check if watch mode and source overriding from scripted tests works


### PR DESCRIPTION
Instead of populating scripted test directory with sources, use generated scripted test directory, which is placed in target directory and is a result of combining sources and scripted tests. In case of a file collision, scripted tests have priority.